### PR TITLE
Return accuracy as fraction matched

### DIFF
--- a/milk/measures/measures.py
+++ b/milk/measures/measures.py
@@ -41,7 +41,7 @@ def accuracy(real, other=None, normalisedlabels=False, names=None):
         cmatrix = np.asanyarray(real)
         return cmatrix.trace()/cmatrix.sum()
     else:
-        return np.mean(np.asanyarray(real) != other)
+        return np.mean(np.asanyarray(real) == other)
 
 def zero_one_loss(real, predicted, normalisedlabels=False, names=None):
     '''


### PR DESCRIPTION
Schematically,
  sum(actual == predicted)/size(actual)
gives the fracton accurately predicted, which is what this
function should return, as inferred from the docs. Before
this patch, it was computing the fraction missed, ie
 sum(actual != predicted)/size(actual)
