### PR TITLE
function is defined as set_max_processors() not set_max_procs()

### DIFF
--- a/docs/source/parallel.rst
+++ b/docs/source/parallel.rst
@@ -81,7 +81,7 @@ without an argument sets the number of processes to the number of CPUs).
     from milksets.wine import load
 
     # Use all available processors
-    parallel.set_max_procs()
+    parallel.set_max_processors()
 
     # Load the data
     features, labels = load()
@@ -101,7 +101,7 @@ Naturally, you can combine both of these features::
     from milksets.wine import load
 
     # Use all available processors
-    parallel.set_max_procs()
+    parallel.set_max_processors()
 
     # Load the data
     features, labels = load()


### PR DESCRIPTION
Hi luis

just a minor change to the docs to correctly show how to enable multiprocessing. thanks for all your work!
